### PR TITLE
Add !gen_mqtt_[username|password|broker] & !gen_device_name directives.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY docker/platformio.ini /pio/platformio.ini
 RUN platformio run -d /pio; rm -rf /pio
 
 COPY . .
-RUN pip install --no-cache-dir --no-binary :all: -e . && \
+RUN pip install --no-cache-dir --no-binary :all: ptvsd hvac==0.2.17 -e . && \
     pip install --no-cache-dir pillow
 
 WORKDIR /config

--- a/esphomeyaml/__main__.py
+++ b/esphomeyaml/__main__.py
@@ -488,6 +488,7 @@ def run_esphomeyaml(argv):
 
     CORE.config_path = args.configuration
 
+    yaml_util.setCommand(args.command)
     config = read_config(args.verbose)
     if config is None:
         return 1


### PR DESCRIPTION
Added directives to enable the creation of mqtt credentials at compile time. 
In order to determine 

```!gen_device_name``` will turn the filename (minus .yaml) into the device name. This enforces a 1-1 relation between devices and files, enabling HAL control via file management. 

```!gen_mqtt_username``` an alias for ```!gen_device_name```

```!gen_mqtt_password``` will get a random password from vault, create a new mqtt user based off the device name and the generated password. 
I had to add add a line in \__main__.py so that the directive can look at that object and sanitize the password if it's just being validated. 

```!gen_mqtt_broker``` will return whatever the MQTT_BROKER env var is set to. 


I also figured out how to debug. You can start the debugger on the main program via:
```ENTRYPOINT ["python", "-m", "ptvsd", "--host", "0.0.0.0", "--port", "5678", "--wait", "/usr/src/app/esphomeyaml"]``` in the Dockerfile. 
However, I found that all the sub programs (upload, edit, logs, and validate) were ran in different threads and thus didn't trigger the breakpoints. So I instead added ```import ptvsd``` to the rest of the imports and the following into a function (outside of a function didn't work)
```
ptvsd.enable_attach()
ptvsd.wait_for_attach()
```

I have ptvsd's default port (5678) mapped to 6051 so that I don't have port conflicts with the Home Assistant debugger. 

I also added the creation of the esphomeyaml mqtt user to a migration in 

Also see:
https://github.com/SciFiFarms/TechnoCore/commit/ad03f5532df7eba92c242b0d2de55b0fc19f5cfd
https://github.com/SciFiFarms/TechnoCore-Portainer/commit/7fd8e5756523bede680806e1c87bd9ffdf47bbcd
https://github.com/SciFiFarms/TechnoCore-esphomeyaml-Wrapper/commit/f8c8c220d93b6cfde8e00c8f7e6a9ffe00a0b244
https://github.com/SciFiFarms/TechnoCore-NGINX/commit/18b9f647b93ef0d61445966dc334f6ed5f33b348