### PR TITLE
Reimplement mqtt credential generator

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,8 @@
 ARG BUILD_FROM=esphome/esphome-base-amd64:1.7.0
 FROM ${BUILD_FROM}
 
+# TODO: hvac 0.2.17 is pretty out of date.
+RUN pip install --no-cache-dir ptvsd==4.1.4 hvac==0.2.17 
 COPY . .
 RUN pip2 install --no-cache-dir -e .
 

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -463,6 +463,9 @@ def run_esphome(argv):
 
     CORE.config_path = args.configuration
 
+    # Added so that the creds generator for TecnoCore knows if it should sanitize passwords or not. 
+    CORE.command = args.command
+
     config = read_config(args.verbose)
     if config is None:
         return 1


### PR DESCRIPTION
This is reimplements [PR 2](https://github.com/SciFiFarms/TechnoCore-ESPHome/pull/2). Going from 1.12 to 1.13 I think SafeLineLoader got move/removed, so I moved to using CORE to keep track of the command ran. I also added comments for debugging. 